### PR TITLE
Add missing filename parameter to NoteMedia

### DIFF
--- a/src/types/note.ts
+++ b/src/types/note.ts
@@ -10,6 +10,7 @@ type NoteModel =
 	| (string & {}) // Allow arbitrary strings too
 
 type NoteMedia = {
+	filename: string
 	data?: string // First priority, must have one of these three
 	fields: string[]
 	path?: string // Second priority, must have one of these three


### PR DESCRIPTION
`filename` is missing when dealing with the requests using NoteMedia.

This is actually required according to the docs:

https://git.sr.ht/~foosoft/anki-connect#codeaddnotecode

> If you choose to include any of them, they should contain a single object or an array of objects with the **mandatory filename field** and one of data, path or url. Refer to the documentation of storeMediaFile for an explanation of these fields.

But not sure if this should be merged as being required, as a breaking change. Without it, AnkiConnect does add in a default under the hood, but this parameter is critical for proper media management. It should be optional at the least.